### PR TITLE
Improves Safari performance by disabling 3D animations

### DIFF
--- a/src/components/layout/about/aboutme/mode-toggle-link.tsx
+++ b/src/components/layout/about/aboutme/mode-toggle-link.tsx
@@ -8,6 +8,7 @@ import { useThemeTransition } from '@/components/ui/theme-toggle'
 import { captureDarkModeEasterEgg } from '@/hooks/posthog'
 import { buildPerThemeVariantCss } from '@/lib/theme-css'
 import { themes } from '@/lib/themes'
+import { isSafari } from '@/lib/utils'
 
 export function ModeToggleNote() {
   const noteCss = useMemo(() => {
@@ -35,6 +36,11 @@ export function ModeToggleLink() {
   const { startTransition } = useThemeTransition()
 
   const injectCircleBlurTransitionStyles = useCallback((originXPercent: number, originYPercent: number) => {
+    // Skip circle-blur animation in Safari due to 3D performance issues
+    if (isSafari()) {
+      return
+    }
+
     const styleId = `theme-transition-${globalThis.crypto?.randomUUID?.() ?? Date.now()}`
     const style = document.createElement('style')
     style.id = styleId

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -11,7 +11,7 @@ import { captureThemeChanged } from '@/hooks/posthog'
 import { buildPerThemeVariantCss } from '@/lib/theme-css'
 import { getAvailableThemes, getDefaultThemeForNow } from '@/lib/theme-runtime'
 import { getThemeIcon, getThemeLabel, themes, type Theme } from '@/lib/themes'
-import { cn } from '@/lib/utils'
+import { cn, isSafari } from '@/lib/utils'
 
 function SystemIcon({ className }: { className?: string }) {
   return (
@@ -448,7 +448,8 @@ export function ThemeToggle({
 
 export const useThemeTransition = () => {
   const startTransition = useCallback((updateFn: () => void) => {
-    if ('startViewTransition' in document) {
+    // Disable view transitions in Safari due to 3D animation performance issues
+    if ('startViewTransition' in document && !isSafari()) {
       document.startViewTransition(updateFn)
     } else {
       updateFn()

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -41,3 +41,19 @@ export function calculateAgeYears(value: string | undefined, now: Date = new Dat
   if (beforeBirthdayThisYear) years--
   return Math.max(0, years)
 }
+
+/**
+ * Detects if the current browser is Safari
+ * @returns true if the browser is Safari, false otherwise
+ */
+export function isSafari(): boolean {
+  if (typeof window === 'undefined') return false
+
+  const userAgent = window.navigator.userAgent
+  const isSafariUA = /Safari/.test(userAgent) && !/Chrome/.test(userAgent) && !/Chromium/.test(userAgent)
+
+  // Additional check for Safari-specific features
+  const hasSafariFeatures = 'webkitAppearance' in document.documentElement.style && !('chrome' in window)
+
+  return isSafariUA || hasSafariFeatures
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -50,7 +50,7 @@ export function isSafari(): boolean {
   if (typeof window === 'undefined') return false
 
   const userAgent = window.navigator.userAgent
-  const isSafariUA = /Safari/.test(userAgent) && !/Chrome/.test(userAgent) && !/Chromium/.test(userAgent)
+  const isSafariUA = userAgent.includes('Safari') && !userAgent.includes('Chrome') && !userAgent.includes('Chromium')
 
   // Additional check for Safari-specific features
   const hasSafariFeatures = 'webkitAppearance' in document.documentElement.style && !('chrome' in window)

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -327,9 +327,19 @@ html::-webkit-scrollbar-thumb:hover {
     filter: none !important;
   }
 
-  /* Disable 3D transforms in Safari */
-  *[style*='transform'] {
-    transform: none !important;
+  /* Disable problematic 3D transforms in Safari while preserving 2D transforms */
+  *[style*='translate3d'],
+  *[style*='translateZ'],
+  *[style*='rotateX'],
+  *[style*='rotateY'],
+  *[style*='rotateZ'],
+  *[style*='perspective'],
+  *[style*='matrix3d'],
+  *[style*='scale3d'],
+  *[style*='transform-style: preserve-3d'] {
+    transform: translateX(var(--tw-translate-x, 0)) translateY(var(--tw-translate-y, 0)) rotate(var(--tw-rotate, 0deg))
+      scaleX(var(--tw-scale-x, 1)) scaleY(var(--tw-scale-y, 1)) !important;
+    transform-style: flat !important;
   }
 
   /* Disable view transition animations in Safari */

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -317,3 +317,38 @@ html::-webkit-scrollbar-thumb {
 html::-webkit-scrollbar-thumb:hover {
   background-color: color-mix(in oklch, var(--primary) 85%, transparent);
 }
+
+/* Safari-specific overrides to disable 3D animations that cause performance issues */
+@supports (-webkit-appearance: none) and (not (background: -webkit-named-image(i))) {
+  /* Disable the theme toggle spin animation in Safari */
+  .theme-system-overlay-anim {
+    animation: none !important;
+    transform: none !important;
+    filter: none !important;
+  }
+
+  /* Disable 3D transforms in Safari */
+  *[style*='transform'] {
+    transform: none !important;
+  }
+
+  /* Disable view transition animations in Safari */
+  @supports (view-transition-name: root) {
+    ::view-transition-old(root),
+    ::view-transition-new(root) {
+      animation: none !important;
+      clip-path: none !important;
+      filter: none !important;
+    }
+  }
+
+  /* Disable the kd-spin-trail keyframe animation in Safari */
+  @keyframes kd-spin-trail {
+    0%,
+    70%,
+    100% {
+      transform: none !important;
+      filter: none !important;
+    }
+  }
+}


### PR DESCRIPTION
Disables specific 3D animations and transitions in Safari to address performance issues.

- Adds a utility function to detect Safari browser.
- Skips circle-blur animation and view transitions in Safari.
- Introduces CSS overrides to disable theme toggle spin animation, 3D transforms, and view transition animations specifically for Safari.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Improved Safari stability by disabling heavy animations and view transitions to reduce flicker and jank during theme changes.
  - Ensured theme toggling falls back gracefully when browser view-transition support is unavailable.

- Style
  - Applied Safari-specific CSS to neutralize 3D transforms and spin effects for smoother interactions without affecting other browsers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->