### PR TITLE
fix: card clipping in safari

### DIFF
--- a/src/components/layout/about/pets/pet-card/card-back.tsx
+++ b/src/components/layout/about/pets/pet-card/card-back.tsx
@@ -19,7 +19,7 @@ export function PetCardBack({ pet }: PetCardBackProps) {
   return (
     <Card className="absolute inset-0 overflow-hidden p-6 [backface-visibility:hidden] transition-shadow bg-transparent group-hover:shadow-md group-hover:ring-2 group-hover:ring-primary group-hover:ring-offset-2 group-hover:ring-offset-background">
       <div aria-hidden className="absolute inset-0">
-        <div className="absolute inset-0 bg-(--card-backdrop) card-back-shadow" />
+        <div className="absolute inset-0 bg-(--card-backdrop) card-back-shadow rounded-[13px]" />
       </div>
 
       <ScrollArea className="relative z-10 h-full">

--- a/src/components/layout/projects/project-card/card-back.tsx
+++ b/src/components/layout/projects/project-card/card-back.tsx
@@ -20,7 +20,7 @@ export function ProjectCardBack({ project }: ProjectCardBackProps) {
     <Card className="absolute inset-0 overflow-hidden p-6 [backface-visibility:hidden] transition-shadow bg-transparent group-hover:shadow-md group-hover:ring-2 group-hover:ring-primary group-hover:ring-offset-2 group-hover:ring-offset-background">
       {/* Backdrop overlay over shared background (blur comes from background image on flip) */}
       <div aria-hidden className="absolute inset-0">
-        <div className="absolute inset-0 bg-(--card-backdrop) card-back-shadow" />
+        <div className="absolute inset-0 bg-(--card-backdrop) card-back-shadow rounded-[13px]" />
       </div>
 
       <div className="relative z-10 flex h-full flex-col">

--- a/src/components/ui/flipping-card.tsx
+++ b/src/components/ui/flipping-card.tsx
@@ -202,12 +202,12 @@ export function FlippingCard({
               />
             </div>
           ) : null}
-          <div className="absolute inset-0 rotate-y-0 [backface-visibility:hidden]">
+          <div className="absolute inset-0 rotate-y-0 [backface-visibility:hidden] overflow-hidden rounded-xl">
             {front}
             <FlipIndicator labelDesktop={flipLabelFrontDesktop} labelMobile={flipLabelFrontMobile} />
           </div>
 
-          <div className="absolute inset-0 rotate-y-180 [backface-visibility:hidden]">
+          <div className="absolute inset-0 rotate-y-180 [backface-visibility:hidden] overflow-hidden rounded-xl">
             {back}
             <FlipIndicator labelDesktop={flipLabelBackDesktop} labelMobile={flipLabelBackMobile} />
           </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Style
  - Rounded corners added to card backdrops on Pet and Project cards for a more polished look.
  - Flipping cards now have rounded corners on both faces, with content clipped to edges for cleaner visuals.

- Bug Fixes
  - Prevented content from overflowing beyond card edges during flip animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->