### PR TITLE
[codex] Fix theme tapdance menu refresh

### DIFF
--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -29,6 +29,8 @@ import {
 } from 'react'
 import { ThemeOptionsPanel, ThemeOptionsSheet } from './theme-options-panel'
 
+const THEME_TAPDANCE_OPEN_THRESHOLD = 5
+
 function SystemIcon({ className }: Readonly<{ className?: string }>) {
   // Avoid hydration mismatch: default to Seasonal icon until mounted
   const { seasonalOverlaysEnabled } = useTheme()
@@ -45,6 +47,7 @@ export function ThemeToggle() {
   const { unlocked, has, unlock } = useAchievements()
 
   const currentPreference: Theme = theme ?? 'system'
+  const themeTapdanceUnlocked = has('THEME_TAPDANCE')
 
   const [tooltipHold, setTooltipHold] = useState(false)
   const [toggleCount, setToggleCount] = useState(0)
@@ -106,7 +109,7 @@ export function ThemeToggle() {
       setToggleCount(0)
 
       // Check if the theme is available
-      const availableThemes = getAvailableThemes() as readonly Theme[]
+      const availableThemes = getAvailableThemes(undefined, themeTapdanceUnlocked) as readonly Theme[]
 
       // Only proceed if the theme is available
       if (!availableThemes.includes(nextPref)) {
@@ -159,7 +162,16 @@ export function ThemeToggle() {
       }
       setOpen(false)
     },
-    [currentPreference, injectCircleBlur, resolvedTheme, setTheme, startTransition, systemTheme, setOpen],
+    [
+      currentPreference,
+      injectCircleBlur,
+      resolvedTheme,
+      setTheme,
+      startTransition,
+      systemTheme,
+      setOpen,
+      themeTapdanceUnlocked,
+    ],
   )
 
   type IconComponent = ComponentType<{ className?: string }>
@@ -168,8 +180,7 @@ export function ThemeToggle() {
   const iconByTheme = useMemo<Partial<Record<Theme, IconComponent>>>(() => ({ system: SystemIcon }), [])
 
   const allOptions: ThemeOption[] = useMemo(() => {
-    const themeList: readonly Theme[] = getAvailableThemes() as readonly Theme[]
-    const achievementUnlocked = has('THEME_TAPDANCE')
+    const themeList: readonly Theme[] = getAvailableThemes(undefined, themeTapdanceUnlocked) as readonly Theme[]
     const hasUnlockedMatrix = isMatrixThemeUnlocked()
     const hasUnlockedDotcom = isDotcomThemeUnlocked()
     const filteredList = themeList.filter(t => {
@@ -180,14 +191,14 @@ export function ThemeToggle() {
       if (entry?.hiddenFromMenu && !((hasUnlockedMatrix && t === 'matrix') || (hasUnlockedDotcom && t === 'dotcom')))
         return false
       const gated = Boolean(entry?.requiresAchievement)
-      return achievementUnlocked || !gated
+      return themeTapdanceUnlocked || !gated
     })
     return filteredList.map((t): ThemeOption => {
       const label: string = getThemeLabel(t)
       const resolvedIcon: IconComponent = iconByTheme[t] ?? getThemeIcon(t, SystemIcon)
       return { label, value: t, Icon: resolvedIcon }
     })
-  }, [iconByTheme, has])
+  }, [iconByTheme, themeTapdanceUnlocked])
 
   // Compute dynamic width based on the longest theme label (in ch units)
   const menuWidthCh = useMemo(() => {
@@ -204,7 +215,9 @@ export function ThemeToggle() {
       const entry = themes.find(e => e.name === opt.value) as ThemeConfig | undefined
       return entry && !('timeRange' in entry)
     })
-    const seasonalActiveNames = new Set((getAvailableThemes() as readonly Theme[]).filter(t => t !== 'system'))
+    const seasonalActiveNames = new Set(
+      (getAvailableThemes(undefined, themeTapdanceUnlocked) as readonly Theme[]).filter(t => t !== 'system'),
+    )
     const seasonalActive = allOptions.filter(opt => {
       if (opt.value === 'system') return false
       const entry = themes.find(e => e.name === opt.value) as ThemeConfig | undefined
@@ -219,7 +232,7 @@ export function ThemeToggle() {
         ? list.filter(opt => opt.value !== 'system')
         : list.filter(opt => opt.value !== currentPreference)
     return list
-  }, [allOptions, currentPreference])
+  }, [allOptions, currentPreference, themeTapdanceUnlocked])
 
   // focus behavior handled in useThemeMenuState
 
@@ -249,33 +262,27 @@ export function ThemeToggle() {
             aria-expanded={open}
             aria-controls="theme-options"
             onClick={() => {
-              setOpen(o => {
-                const next = !o
+              const next = !open
 
-                // When opening the menu, reset theme selection tracking
-                if (!o && next) {
-                  setThemeSelected(false)
-                }
+              // When opening the menu, reset theme selection tracking
+              if (next) {
+                setThemeSelected(false)
+                const newCount = toggleCount + 1
 
-                // When closing the menu, only increment if no theme was selected
-                if (o && !next && !themeSelected) {
-                  const newCount = toggleCount + 1
-                  setToggleCount(newCount)
-
-                  // Unlock achievement after 6 toggles
-                  if (newCount >= 6 && !has('THEME_TAPDANCE')) {
-                    unlock('THEME_TAPDANCE')
-                    setToggleCount(0) // Reset counter after unlocking
-                  }
-                }
-
-                // If a theme was selected, reset the counter
-                if (o && !next && themeSelected) {
+                if (newCount >= THEME_TAPDANCE_OPEN_THRESHOLD && !themeTapdanceUnlocked) {
+                  unlock('THEME_TAPDANCE')
                   setToggleCount(0)
+                } else {
+                  setToggleCount(newCount)
                 }
+              }
 
-                return next
-              })
+              // If a theme was selected, reset the counter
+              if (!next && themeSelected) {
+                setToggleCount(0)
+              }
+
+              setOpen(next)
             }}
             onKeyDown={handleTriggerKeyDown}
             className={cn(

--- a/tests/e2e/flows/achievements/theme-tapdance.spec.ts
+++ b/tests/e2e/flows/achievements/theme-tapdance.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test, type Page } from '@playwright/test'
 import { expectAchievementCookieContains, expectConfettiLikely } from '../../fixtures/achievement-helpers'
 import { abortNoise, clearState, closeThemeMenu, gotoAndWaitForMain, openThemeMenu } from '../../fixtures/test-helpers'
 
@@ -22,6 +22,16 @@ test.describe('THEME_TAPDANCE Achievement', () => {
     expect(total).toBeLessThan(4)
   })
 
+  async function expectAllUnlockedSeasonalThemesVisible(page: Page) {
+    const menu = page.locator('#theme-options')
+    await expect(menu).toHaveAttribute('aria-hidden', 'false')
+    await Promise.all(
+      ['Pride', 'Halloween', 'Thanksgiving', 'Christmas'].map(name =>
+        expect(menu.getByRole('menuitem', { name })).toBeVisible(),
+      ),
+    )
+  }
+
   test('should reset counter if theme is selected', async ({ page }) => {
     await gotoAndWaitForMain(page, '/')
 
@@ -41,39 +51,50 @@ test.describe('THEME_TAPDANCE Achievement', () => {
     await themeOption.click()
     await page.waitForTimeout(500)
 
-    // Now open/close 6 more times (counter should have reset)
-    for (let i = 0; i < 6; i++) {
+    // Now open/close 4 more times (counter should have reset and not unlocked yet)
+    for (let i = 0; i < 4; i++) {
       await openThemeMenu(page)
       await page.waitForTimeout(200)
       await page.locator('button[aria-controls="theme-options"]').first().click()
       await page.waitForTimeout(200)
     }
 
-    // Wait for achievement
-    await page.waitForTimeout(1500)
+    await expect
+      .poll(async () => page.evaluate(() => document.documentElement.dataset.achievementThemeTapdance), {
+        timeout: 100,
+      })
+      .not.toBe('true')
 
-    // Should now be unlocked
+    await openThemeMenu(page)
+
+    await page.waitForFunction(
+      () => {
+        return document.documentElement.dataset.achievementThemeTapdance === 'true'
+      },
+      { timeout: 3000 },
+    )
     await expectAchievementCookieContains(page, 'THEME_TAPDANCE')
   })
 
-  test('should unlock THEME_TAPDANCE after opening/closing theme menu 6 times', async ({ page }) => {
+  test('should unlock THEME_TAPDANCE on the 5th theme menu open and reveal seasonal themes immediately', async ({
+    page,
+  }) => {
     await gotoAndWaitForMain(page, '/')
 
-    // Open and close theme menu 6 times
-    // The counter increments when closing without selecting a theme
-    for (let i = 0; i < 6; i++) {
+    // Open and close theme menu 4 times without selecting a theme.
+    for (let i = 0; i < 4; i++) {
       await openThemeMenu(page)
       // Wait for menu to be fully open
       await page.waitForSelector('#theme-options[aria-hidden="false"]', { state: 'attached', timeout: 1000 })
       await page.waitForTimeout(100) // Small delay to ensure state is stable
-      // Close by toggling the button again, which is how the counter increments
       await page.locator('button[aria-controls="theme-options"]').first().click()
       // Wait for menu to be fully closed before next iteration
       await page.waitForSelector('#theme-options[aria-hidden="true"]', { state: 'attached', timeout: 1000 })
       await page.waitForTimeout(100) // Small delay to ensure state updates are processed
     }
 
-    // Wait for achievement to process - check for data attribute as a reliable indicator
+    await openThemeMenu(page)
+
     await page.waitForFunction(
       () => {
         return document.documentElement.dataset.achievementThemeTapdance === 'true'
@@ -84,6 +105,9 @@ test.describe('THEME_TAPDANCE Achievement', () => {
     // Verify achievement is unlocked
     await expectAchievementCookieContains(page, 'THEME_TAPDANCE')
 
+    // Verify the newly unlocked themes are visible in the menu that is already open.
+    await expectAllUnlockedSeasonalThemesVisible(page)
+
     // Verify confetti was triggered (theme tapdance has confetti)
     await expectConfettiLikely(page)
   })
@@ -91,11 +115,11 @@ test.describe('THEME_TAPDANCE Achievement', () => {
   test('should unlock all seasonal themes after THEME_TAPDANCE', async ({ page }) => {
     await gotoAndWaitForMain(page, '/')
 
-    // Unlock THEME_TAPDANCE by opening/closing menu 6 times
-    for (let i = 0; i < 6; i++) {
+    // Unlock THEME_TAPDANCE by opening the menu 5 times
+    for (let i = 0; i < 5; i++) {
       await openThemeMenu(page)
       await page.waitForTimeout(200)
-      await closeThemeMenu(page)
+      if (i < 4) await closeThemeMenu(page)
       await page.waitForTimeout(200)
     }
 


### PR DESCRIPTION
## Summary
- unlock Theme Tapdance on the fifth menu open instead of after a later close
- build the theme menu from the live achievement state so newly unlocked seasonal themes appear immediately
- add e2e coverage for the fifth-open unlock and already-open menu state

## Root Cause
The menu was deriving availability from DOM/localStorage mirrors that update after the achievement context changes, so the first render after unlocking could still use the old locked theme list.

## Validation
- bun run test:e2e -- tests/e2e/flows/achievements/theme-tapdance.spec.ts --project=chromium-desktop
- bun run check
- bunx prettier --check src/components/ui/theme-toggle.tsx tests/e2e/flows/achievements/theme-tapdance.spec.ts
- in-app browser sanity check on http://localhost:3000: fifth open showed all unlocked seasonal themes immediately with no console warnings/errors