### PR TITLE
Trust mise config during Codex setup

### DIFF
--- a/scripts/codex/setup.sh
+++ b/scripts/codex/setup.sh
@@ -15,6 +15,10 @@ fi
 cd "${repo_root}"
 
 if command -v mise >/dev/null 2>&1; then
+  if [[ -f "${repo_root}/mise.toml" ]]; then
+    mise trust "${repo_root}/mise.toml"
+  fi
+
   mise install
 fi
 


### PR DESCRIPTION
## Summary
- trust the worktree-local mise.toml before running mise install in Codex setup
- fixes Codex worktree setup failing on untrusted mise config

## Verification
- bash -n scripts/codex/setup.sh scripts/codex/setup-worktree-local-config.sh .githooks/post-checkout
- bun run test scripts/codex/setup-worktree-local-config.test.ts
- bun run check
- fresh detached git worktree from this commit ran ./scripts/codex/setup.sh successfully