### PR TITLE
Animate gated topbar reveals

### DIFF
--- a/src/components/layout/header/nav-lava.tsx
+++ b/src/components/layout/header/nav-lava.tsx
@@ -95,6 +95,33 @@ export function NavLava() {
     hideIndicator()
   }, [activeIndex, moveIndicatorTo, hideIndicator, activeItems])
 
+  React.useLayoutEffect(() => {
+    const container = containerRef.current
+    if (!container || typeof ResizeObserver === 'undefined') return
+
+    let frameId = 0
+    const scheduleMeasure = () => {
+      cancelAnimationFrame(frameId)
+      frameId = requestAnimationFrame(() => {
+        const activeKey = activeIndex >= 0 ? activeItems[activeIndex]?.href : null
+        const key = hoveredKey ?? activeKey
+        if (key) {
+          moveIndicatorTo(key, didInitRef.current)
+          return
+        }
+        hideIndicator()
+      })
+    }
+
+    const observer = new ResizeObserver(scheduleMeasure)
+    observer.observe(container)
+
+    return () => {
+      cancelAnimationFrame(frameId)
+      observer.disconnect()
+    }
+  }, [activeIndex, activeItems, hoveredKey, moveIndicatorTo, hideIndicator])
+
   const handleMouseLeaveContainer = React.useCallback(() => {
     setHoveredKey(null)
     if (activeIndex >= 0) {
@@ -132,6 +159,7 @@ export function NavLava() {
       const focusable = anchors.filter(el => {
         if (el.hasAttribute('disabled')) return false
         if (el.getAttribute('aria-hidden') === 'true') return false
+        if (globalThis.getComputedStyle(el).visibility === 'hidden') return false
         const tabIndexAttr = el.getAttribute('tabindex')
         if (tabIndexAttr !== null && Number(tabIndexAttr) < 0) return false
         if (el.offsetParent === null) return false
@@ -287,7 +315,7 @@ function NavLink(props: NavLinkProps) {
       href={href}
       ref={node => registerRef(href, node)}
       className={cn(
-        'relative z-10 rounded-md px-3 py-2 text-sm font-medium transition-colors outline-none',
+        'relative z-10 mx-0.5 rounded-md px-3 py-2 text-sm font-medium transition-colors outline-none',
         NAV_TEXT.base,
         NAV_TEXT.hover,
         isActive && (!hoveredKey || hoveredKey === href) ? NAV_TEXT.active : undefined,

--- a/src/components/providers/achievements-provider.tsx
+++ b/src/components/providers/achievements-provider.tsx
@@ -244,7 +244,7 @@ export function AchievementsProvider({
           document.documentElement.dataset.achievementsJustUnlocked = 'true'
           globalThis.window.setTimeout(() => {
             delete document.documentElement.dataset.achievementsJustUnlocked
-          }, 1000)
+          }, 1400)
         }
       } catch {}
     }
@@ -289,7 +289,7 @@ export function AchievementsProvider({
           document.documentElement.dataset.petGalleryJustUnlocked = 'true'
           globalThis.window.setTimeout(() => {
             delete document.documentElement.dataset.petGalleryJustUnlocked
-          }, 1000)
+          }, 1400)
         }
       } catch {}
     }

--- a/src/styles/navigation.css
+++ b/src/styles/navigation.css
@@ -1,24 +1,50 @@
-/* Pre-hydration Achievements menu reveal */
-.js-achievements-nav {
-  display: none;
+/* Pre-hydration gated menu reveal */
+.js-achievements-nav,
+.js-pet-gallery-nav {
+  max-width: 0;
+  margin-inline: 0;
+  padding-inline: 0;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(-0.375rem) scale(0.96);
+  transform-origin: center;
+  visibility: hidden;
+  white-space: nowrap;
+  transition:
+    max-width 520ms cubic-bezier(0.16, 1, 0.3, 1),
+    margin-inline 520ms cubic-bezier(0.16, 1, 0.3, 1),
+    padding-inline 520ms cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 240ms ease-out,
+    transform 420ms cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: max-width, margin-inline, padding-inline, opacity, transform;
 }
 
-html[data-has-achievements='true'] .js-achievements-nav {
-  display: inline-flex;
+html[data-has-achievements='true'] .js-achievements-nav,
+html[data-has-pet-gallery='true'] .js-pet-gallery-nav,
+.js-achievements-nav[aria-current='page'],
+.js-pet-gallery-nav[aria-current='page'] {
+  max-width: 10rem;
+  margin-inline: 0.125rem;
+  padding-inline: 0.75rem;
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(0) scale(1);
+  visibility: visible;
 }
 
 /* Always keep visible while on the current page to avoid nav lava glitches */
 .js-achievements-nav[aria-current='page'],
 .js-pet-gallery-nav[aria-current='page'] {
-  display: inline-flex;
+  pointer-events: auto;
 }
 
 /* Sparkle burst when just unlocked (single session) */
 html[data-has-achievements='true'][data-achievements-just-unlocked='true'] .js-achievements-nav {
   position: relative;
   isolation: isolate;
-  animation: kd-fade-slide-in 220ms ease-out both;
-  will-change: opacity, transform;
+  animation: kd-nav-entry-settle 560ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  pointer-events: none;
 }
 
 html[data-has-achievements='true'][data-achievements-just-unlocked='true'] .js-achievements-nav::after {
@@ -56,21 +82,12 @@ html[data-has-achievements='true'][data-achievements-just-unlocked='true'] .js-a
   }
 }
 
-/* Pre-hydration Pet Gallery menu reveal */
-.js-pet-gallery-nav {
-  display: none;
-}
-
-html[data-has-pet-gallery='true'] .js-pet-gallery-nav {
-  display: inline-flex;
-}
-
 /* Sparkle burst when PET_PARADE just unlocked (single session) */
 html[data-has-pet-gallery='true'][data-pet-gallery-just-unlocked='true'] .js-pet-gallery-nav {
   position: relative;
   isolation: isolate;
-  animation: kd-fade-slide-in 220ms ease-out both;
-  will-change: opacity, transform;
+  animation: kd-nav-entry-settle 560ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  pointer-events: none;
 }
 
 html[data-has-pet-gallery='true'][data-pet-gallery-just-unlocked='true'] .js-pet-gallery-nav::after {
@@ -90,23 +107,34 @@ html[data-has-pet-gallery='true'][data-pet-gallery-just-unlocked='true'] .js-pet
 }
 
 @media (prefers-reduced-motion: reduce) {
-  html[data-has-pet-gallery='true'] .js-pet-gallery-nav {
+  .js-achievements-nav,
+  .js-pet-gallery-nav {
+    transition: none;
+  }
+
+  html[data-has-pet-gallery='true'] .js-pet-gallery-nav,
+  html[data-has-achievements='true'] .js-achievements-nav {
     animation: none;
   }
+
   html[data-has-pet-gallery='true'][data-pet-gallery-just-unlocked='true'] .js-pet-gallery-nav::after {
     animation: none;
     content: none;
   }
 }
 
-@keyframes kd-fade-slide-in {
-  from {
+@keyframes kd-nav-entry-settle {
+  0% {
     opacity: 0;
-    transform: translateY(-4px);
+    transform: translateX(-0.375rem) translateY(-0.125rem) scale(0.96);
   }
-  to {
+  60% {
     opacity: 1;
-    transform: translateY(0);
+    transform: translateX(0.0625rem) translateY(0) scale(1.01);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(0) translateY(0) scale(1);
   }
 }
 

--- a/tests/e2e/flows/achievements/recursive-reward.spec.ts
+++ b/tests/e2e/flows/achievements/recursive-reward.spec.ts
@@ -64,4 +64,79 @@ test.describe('RECURSIVE_REWARD Achievement', () => {
     const achievementsLink = page.locator('.js-achievements-nav')
     await expect(achievementsLink).toBeVisible()
   })
+
+  test('should animate desktop nav layout when achievements link appears', async ({ page }) => {
+    if ((page.viewportSize()?.width ?? 0) < 920) {
+      test.skip(true, 'Desktop topbar is hidden below the nav breakpoint')
+    }
+
+    type NavSample = {
+      achievementsWidth: number
+      achievementsVisible: boolean
+      achievementsPointerEvents: string
+      indicatorCenter: number
+      projectsCenter: number
+      projectsX: number
+    }
+
+    const readNavSample = async (): Promise<NavSample> => {
+      return page.evaluate(() => {
+        const rectOf = (selector: string) => {
+          const element = document.querySelector(selector)
+          if (!element) throw new Error(`Missing element: ${selector}`)
+          return element.getBoundingClientRect()
+        }
+        const nav = document.querySelector('nav[aria-label="Primary"]')
+        const indicator = nav?.querySelector('div > span:nth-child(2)')
+        if (!indicator) throw new Error('Missing nav indicator')
+
+        const achievements = rectOf('.js-achievements-nav')
+        const projects = rectOf('nav[aria-label="Primary"] a[href="/projects"]')
+        const indicatorRect = indicator.getBoundingClientRect()
+
+        return {
+          achievementsWidth: achievements.width,
+          achievementsVisible: achievements.width > 0 && achievements.height > 0,
+          achievementsPointerEvents: getComputedStyle(document.querySelector('.js-achievements-nav')!).pointerEvents,
+          indicatorCenter: indicatorRect.left + indicatorRect.width / 2,
+          projectsCenter: projects.left + projects.width / 2,
+          projectsX: projects.left,
+        }
+      })
+    }
+
+    await gotoAndWaitForMain(page, '/')
+    const initial = await readNavSample()
+    expect(initial.achievementsVisible).toBe(false)
+
+    await gotoAndWaitForMain(page, '/about')
+    await gotoAndWaitForMain(page, '/experience')
+    await page.goto('/projects', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByRole('main')).toBeVisible()
+
+    const samples: NavSample[] = []
+    for (let i = 0; i < 12; i += 1) {
+      samples.push(await readNavSample())
+      await page.waitForTimeout(50)
+    }
+    await page.waitForTimeout(600)
+    const settled = await readNavSample()
+
+    const linkExpandsThroughIntermediateWidths = samples.some(
+      sample => sample.achievementsWidth > 8 && sample.achievementsWidth < settled.achievementsWidth - 8,
+    )
+    const siblingsMoveThroughIntermediatePositions = samples.some(
+      sample => sample.projectsX < initial.projectsX - 8 && sample.projectsX > settled.projectsX + 8,
+    )
+    const pointerGuardActiveDuringReveal = samples.some(
+      sample => sample.achievementsVisible && sample.achievementsPointerEvents === 'none',
+    )
+    const indicatorDistanceFromActiveProject = Math.abs(settled.indicatorCenter - settled.projectsCenter)
+
+    expect(settled.achievementsVisible).toBe(true)
+    expect(linkExpandsThroughIntermediateWidths).toBe(true)
+    expect(siblingsMoveThroughIntermediatePositions).toBe(true)
+    expect(pointerGuardActiveDuringReveal).toBe(true)
+    expect(indicatorDistanceFromActiveProject).toBeLessThan(20)
+  })
 })


### PR DESCRIPTION
## Summary
- animate gated desktop topbar links by expanding width/padding/margins instead of toggling display
- keep the lava indicator aligned while the nav row resizes during a reveal
- add a Playwright regression for the Achievements nav reveal animation

## Validation
- bun run format:check
- bun run check
- bun run test
- bun run test:e2e -- tests/e2e/flows/achievements/recursive-reward.spec.ts
