### PR TITLE
Generate Next types during Codex setup

### DIFF
--- a/scripts/codex/setup.sh
+++ b/scripts/codex/setup.sh
@@ -23,3 +23,4 @@ if command -v mise >/dev/null 2>&1; then
 fi
 
 bun install --frozen-lockfile
+bunx next typegen


### PR DESCRIPTION
## Summary
- run Next type generation during Codex setup so fresh worktrees have next-env.d.ts without starting the dev server
- keeps lint/typecheck workflows usable immediately after setup

## Verification
- bash -n scripts/codex/setup.sh scripts/codex/setup-worktree-local-config.sh .githooks/post-checkout
- bun run test scripts/codex/setup-worktree-local-config.test.ts
- bun run check
- bun run format:check
- fresh detached worktree ran ./scripts/codex/setup.sh and produced next-env.d.ts