### PR TITLE
KTY-35 Fix production WorkOS admin login

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
         "convex": "1.39.1",
         "date-fns": "4.3.0",
         "exifr": "7.1.3",
+        "iron-session": "8.0.4",
         "js-cookie": "3.0.7",
         "lucide-react": "1.16.0",
         "motion": "12.38.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "convex": "1.39.1",
     "date-fns": "4.3.0",
     "exifr": "7.1.3",
+    "iron-session": "8.0.4",
     "js-cookie": "3.0.7",
     "lucide-react": "1.16.0",
     "motion": "12.38.0",

--- a/src/app/auth/callback/route.test.ts
+++ b/src/app/auth/callback/route.test.ts
@@ -1,12 +1,25 @@
 import type * as NextServer from 'next/server'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockAuthHandler = vi.fn()
 const handleAuth = vi.fn(() => mockAuthHandler)
 const connection = vi.fn()
+const sealData = vi.fn()
+
+type MockAuthSuccess = {
+  accessToken?: string
+  refreshToken?: string
+  user?: unknown
+  impersonator?: unknown
+  authenticationMethod?: unknown
+}
 
 vi.mock('@workos-inc/authkit-nextjs', () => ({
   handleAuth,
+}))
+
+vi.mock('iron-session', () => ({
+  sealData,
 }))
 
 vi.mock('next/server', async importActual => ({
@@ -14,15 +27,82 @@ vi.mock('next/server', async importActual => ({
   connection,
 }))
 
+function mockSuccessfulAuthCallback(success: MockAuthSuccess = {}) {
+  mockAuthHandler.mockImplementation(async (_request: Request) => {
+    const calls = handleAuth.mock.calls as unknown as Array<
+      [{ onSuccess: (session: Required<MockAuthSuccess>) => unknown }]
+    >
+    const options = calls.at(-1)?.[0]
+    if (!options) throw new Error('expected handleAuth options')
+    await options.onSuccess({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      user: { id: 'user_admin', email: 'admin@example.test' },
+      impersonator: undefined,
+      authenticationMethod: 'oauth',
+      ...success,
+    })
+    return new Response(null, { status: 307, headers: { Location: '/admin' } })
+  })
+}
+
 describe('AuthKit callback route', () => {
+  beforeEach(() => {
+    vi.stubEnv('WORKOS_COOKIE_PASSWORD', 'a'.repeat(32))
+    vi.resetModules()
+    handleAuth.mockClear()
+    mockAuthHandler.mockReset()
+    connection.mockClear()
+    sealData.mockResolvedValue('sealed-session')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   it('uses the WorkOS AuthKit callback handler at request time', async () => {
     vi.resetModules()
+    mockAuthHandler.mockResolvedValue(new Response(null, { status: 307 }))
     const route = await import('./route')
     const request = new Request('http://localhost:3000/auth/callback') as never
 
-    expect(handleAuth).toHaveBeenCalledWith()
     await route.GET(request)
     expect(connection).toHaveBeenCalledWith()
+    expect(handleAuth).toHaveBeenCalledWith({ onSuccess: expect.any(Function) })
     expect(mockAuthHandler).toHaveBeenCalledWith(request)
+  })
+
+  it('sets the WorkOS session cookie on successful callback redirects', async () => {
+    mockSuccessfulAuthCallback()
+
+    const route = await import('./route')
+    const response = await route.GET(new Request('https://kil.dev/auth/callback') as never)
+
+    expect(sealData).toHaveBeenCalledWith(
+      {
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        user: { id: 'user_admin', email: 'admin@example.test' },
+        impersonator: undefined,
+        authenticationMethod: 'oauth',
+      },
+      { password: 'a'.repeat(32), ttl: 0 },
+    )
+    expect(response.headers.getSetCookie()).toEqual(
+      expect.arrayContaining(['wos-session=sealed-session; Path=/; HttpOnly; SameSite=Lax; Max-Age=34560000; Secure']),
+    )
+  })
+
+  it('honors configured cookie lifetime and secure production redirect settings', async () => {
+    vi.stubEnv('WORKOS_COOKIE_MAX_AGE', '3600')
+    vi.stubEnv('NEXT_PUBLIC_WORKOS_REDIRECT_URI', 'https://kil.dev/auth/callback')
+    mockSuccessfulAuthCallback()
+
+    const route = await import('./route')
+    const response = await route.GET(new Request('http://internal.vercel.test/auth/callback') as never)
+
+    expect(response.headers.getSetCookie()).toEqual(
+      expect.arrayContaining(['wos-session=sealed-session; Path=/; HttpOnly; SameSite=Lax; Max-Age=3600; Secure']),
+    )
   })
 })

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,9 +1,99 @@
 import { handleAuth } from '@workos-inc/authkit-nextjs'
+import { sealData } from 'iron-session'
 import { connection, type NextRequest } from 'next/server'
 
-const handleAuthCallback = handleAuth()
+const WORKOS_SESSION_COOKIE = process.env.WORKOS_COOKIE_NAME || 'wos-session'
+const DEFAULT_WORKOS_COOKIE_MAX_AGE = 60 * 60 * 24 * 400
+
+type AuthKitCookieSession = {
+  accessToken: string
+  refreshToken: string
+  user: unknown
+  impersonator?: unknown
+  authenticationMethod?: unknown
+}
+
+function readCookieSameSite() {
+  const sameSite = process.env.WORKOS_COOKIE_SAMESITE?.trim().toLowerCase()
+  if (sameSite === 'strict' || sameSite === 'none') return sameSite
+  return 'lax'
+}
+
+function readCookieMaxAge() {
+  const configuredMaxAge = process.env.WORKOS_COOKIE_MAX_AGE?.trim()
+  if (!configuredMaxAge) return DEFAULT_WORKOS_COOKIE_MAX_AGE
+
+  const parsedMaxAge = Number.parseInt(configuredMaxAge, 10)
+  return Number.isFinite(parsedMaxAge) ? parsedMaxAge : DEFAULT_WORKOS_COOKIE_MAX_AGE
+}
+
+function shouldSetSecureCookie(request: NextRequest, sameSite: string) {
+  if (sameSite === 'none') return true
+
+  const redirectUri = process.env.NEXT_PUBLIC_WORKOS_REDIRECT_URI?.trim()
+  if (redirectUri) {
+    try {
+      return new URL(redirectUri).protocol === 'https:'
+    } catch {
+      return process.env.NODE_ENV === 'production'
+    }
+  }
+
+  const forwardedProtocol = request.headers.get('x-forwarded-proto')?.split(',')[0]?.trim()
+  if (forwardedProtocol) return forwardedProtocol === 'https'
+
+  const requestUrl = request.nextUrl ?? new URL(request.url)
+  return requestUrl.protocol === 'https:' || process.env.NODE_ENV === 'production'
+}
+
+function serializeWorkOSSessionCookie(request: NextRequest, encryptedSession: string) {
+  const sameSite = readCookieSameSite()
+  const parts = [
+    `${WORKOS_SESSION_COOKIE}=${encryptedSession}`,
+    'Path=/',
+    'HttpOnly',
+    `SameSite=${sameSite.charAt(0).toUpperCase()}${sameSite.slice(1)}`,
+    `Max-Age=${readCookieMaxAge()}`,
+  ]
+
+  const domain = process.env.WORKOS_COOKIE_DOMAIN?.trim()
+  if (domain) parts.push(`Domain=${domain}`)
+
+  if (shouldSetSecureCookie(request, sameSite)) parts.push('Secure')
+
+  return parts.join('; ')
+}
+
+async function sealAuthKitCookieSession(session: AuthKitCookieSession) {
+  const password = process.env.WORKOS_COOKIE_PASSWORD
+  if (!password || password.length < 32) {
+    throw new Error('WORKOS_COOKIE_PASSWORD must be at least 32 characters')
+  }
+
+  return sealData(session, { password, ttl: 0 })
+}
 
 export async function GET(request: NextRequest) {
   await connection()
-  return handleAuthCallback(request)
+  let cookieSession: AuthKitCookieSession | null = null
+  const response = await handleAuth({
+    onSuccess: ({ accessToken, refreshToken, user, impersonator, authenticationMethod }) => {
+      cookieSession = {
+        accessToken,
+        refreshToken,
+        user,
+        impersonator,
+        authenticationMethod,
+      }
+    },
+  })(request)
+
+  if (cookieSession) {
+    response.headers.append(
+      'Set-Cookie',
+      serializeWorkOSSessionCookie(request, await sealAuthKitCookieSession(cookieSession)),
+    )
+  }
+
+  return response
 }


### PR DESCRIPTION
## Summary
- Explicitly attach the sealed WorkOS AuthKit session cookie to the `/auth/callback` redirect response after a successful callback
- Add regression coverage that the callback response includes `wos-session`
- Add `iron-session` as an explicit dependency because the callback now seals the session directly

## Production evidence
- Production logs showed `GET /auth/callback` returning 307, followed by `/admin` rendering without a readable session and redirecting back to `/auth/sign-in`
- This targets the deployed-only session persistence gap rather than WorkOS org membership or Convex authorization

## Verification
- `bun run test src/app/auth/callback/route.test.ts`
- `bun run check`
- `bun run build`

Closes KTY-35