### PR TITLE
KTY-35 Force admin gallery request rendering

### DIFF
--- a/src/app/admin/pet-gallery/page.test.tsx
+++ b/src/app/admin/pet-gallery/page.test.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+const connection = vi.fn()
+const getPetGalleryAdminWorkspaceStateAction = vi.fn(async () => ({ kind: 'workspace-state' }))
+
+vi.mock('next/server', () => ({
+  connection,
+}))
+
+vi.mock('./actions', () => ({
+  getPetGalleryAdminWorkspaceStateAction,
+}))
+
+vi.mock('@/components/admin/admin-shell', () => ({
+  AdminShell: ({ children }: { children: ReactNode }) => <section>{children}</section>,
+}))
+
+vi.mock('@/components/admin/pet-gallery/pet-gallery-admin-client', () => ({
+  PetGalleryAdminClient: ({ initialState }: { initialState: unknown }) => (
+    <div data-initial-state={JSON.stringify(initialState)} />
+  ),
+}))
+
+describe('AdminPetGalleryPage', () => {
+  it('waits for a request before reading authenticated pet gallery state', async () => {
+    const { default: AdminPetGalleryPage } = await import('./page')
+
+    await AdminPetGalleryPage()
+
+    expect(connection).toHaveBeenCalledWith()
+    expect(getPetGalleryAdminWorkspaceStateAction).toHaveBeenCalledWith()
+    expect(connection.mock.invocationCallOrder[0]).toBeLessThan(
+      getPetGalleryAdminWorkspaceStateAction.mock.invocationCallOrder[0] ?? 0,
+    )
+  })
+})

--- a/src/app/admin/pet-gallery/page.tsx
+++ b/src/app/admin/pet-gallery/page.tsx
@@ -1,8 +1,10 @@
 import { AdminShell } from '@/components/admin/admin-shell'
 import { PetGalleryAdminClient } from '@/components/admin/pet-gallery/pet-gallery-admin-client'
+import { connection } from 'next/server'
 import { getPetGalleryAdminWorkspaceStateAction } from './actions'
 
 export default async function AdminPetGalleryPage() {
+  await connection()
   const initialState = await getPetGalleryAdminWorkspaceStateAction()
 
   return (

--- a/src/app/admin/pet-gallery/preview/page.tsx
+++ b/src/app/admin/pet-gallery/preview/page.tsx
@@ -2,9 +2,11 @@ import { AdminShell } from '@/components/admin/admin-shell'
 import { ClientMounted, GalleryClient } from '@/components/layout/pet-gallery/gallery-client'
 import { ServerAlbum } from '@/components/layout/pet-gallery/server-album'
 import { buildPublicPetGallerySnapshot } from '@/lib/pet-gallery/snapshot'
+import { connection } from 'next/server'
 import { getPetGalleryAdminWorkspaceStateAction } from '../actions'
 
 export default async function AdminPetGalleryPreviewPage() {
+  await connection()
   const state = await getPetGalleryAdminWorkspaceStateAction()
   const snapshot = buildPublicPetGallerySnapshot({
     photos: state.photos,


### PR DESCRIPTION
## Summary
- force the admin pet gallery and draft preview pages to wait for an incoming request before reading authenticated state
- add a regression test that the page calls `connection()` before loading pet gallery admin state

## Why
Production logs showed `/admin/pet-gallery` returning `cache: HIT` while replaying `PetGalleryAdminUnauthorizedError`. The authenticated state read needs its own request-time boundary, not only the parent admin layout gate.

## Verification
- `bun run test src/app/admin/pet-gallery/page.test.tsx src/app/admin/layout.test.tsx`
- `bun run check`
- `bun run format:check`
- `bun run build`