### PR TITLE
KTY-35 Persist WorkOS callback cookie via NextResponse

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as _utils from "../_utils.js";
 import type * as auth from "../auth.js";
+import type * as authConfigProviders from "../authConfigProviders.js";
 import type * as dev_seedScores from "../dev/seedScores.js";
 import type * as gameSessions from "../gameSessions.js";
 import type * as http from "../http.js";
@@ -29,6 +30,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   _utils: typeof _utils;
   auth: typeof auth;
+  authConfigProviders: typeof authConfigProviders;
   "dev/seedScores": typeof dev_seedScores;
   gameSessions: typeof gameSessions;
   http: typeof http;

--- a/src/app/admin/page.test.tsx
+++ b/src/app/admin/page.test.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const connection = vi.fn()
+
+vi.mock('next/server', () => ({
+  connection,
+}))
+
+describe('AdminPage', () => {
+  it('waits for a request before rendering the authenticated admin landing page', async () => {
+    const { default: AdminPage } = await import('./page')
+
+    await AdminPage()
+
+    expect(connection).toHaveBeenCalledWith()
+  })
+})

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,8 +2,11 @@ import { AdminShell } from '@/components/admin/admin-shell'
 import { LinkButton } from '@/components/ui/link-button'
 import { Images } from 'lucide-react'
 import type { Route } from 'next'
+import { connection } from 'next/server'
 
-export default function AdminPage() {
+export default async function AdminPage() {
+  await connection()
+
   return (
     <AdminShell title="Admin" description="Private tools for kil.dev.">
       <div className="flex">

--- a/src/app/auth/callback/route.test.ts
+++ b/src/app/auth/callback/route.test.ts
@@ -28,7 +28,7 @@ vi.mock('next/server', async importActual => ({
 }))
 
 function mockSuccessfulAuthCallback(success: MockAuthSuccess = {}) {
-  mockAuthHandler.mockImplementation(async (_request: Request) => {
+  mockAuthHandler.mockImplementation(async (request: Request) => {
     const calls = handleAuth.mock.calls as unknown as Array<
       [{ onSuccess: (session: Required<MockAuthSuccess>) => unknown }]
     >
@@ -42,7 +42,8 @@ function mockSuccessfulAuthCallback(success: MockAuthSuccess = {}) {
       authenticationMethod: 'oauth',
       ...success,
     })
-    return new Response(null, { status: 307, headers: { Location: '/admin' } })
+    const { NextResponse } = await import('next/server')
+    return NextResponse.redirect(new URL('/admin', request.url))
   })
 }
 
@@ -88,9 +89,12 @@ describe('AuthKit callback route', () => {
       },
       { password: 'a'.repeat(32), ttl: 0 },
     )
-    expect(response.headers.getSetCookie()).toEqual(
-      expect.arrayContaining(['wos-session=sealed-session; Path=/; HttpOnly; SameSite=Lax; Max-Age=34560000; Secure']),
-    )
+    expect(response.headers.getSetCookie()[0]).toEqual(expect.stringContaining('wos-session=sealed-session;'))
+    expect(response.headers.getSetCookie()[0]).toEqual(expect.stringContaining('Path=/'))
+    expect(response.headers.getSetCookie()[0]).toEqual(expect.stringContaining('HttpOnly'))
+    expect(response.headers.getSetCookie()[0]).toEqual(expect.stringContaining('SameSite=lax'))
+    expect(response.headers.getSetCookie()[0]).toEqual(expect.stringContaining('Max-Age=34560000'))
+    expect(response.headers.getSetCookie()[0]).toEqual(expect.stringContaining('Secure'))
   })
 
   it('honors configured cookie lifetime and secure production redirect settings', async () => {
@@ -101,8 +105,8 @@ describe('AuthKit callback route', () => {
     const route = await import('./route')
     const response = await route.GET(new Request('http://internal.vercel.test/auth/callback') as never)
 
-    expect(response.headers.getSetCookie()).toEqual(
-      expect.arrayContaining(['wos-session=sealed-session; Path=/; HttpOnly; SameSite=Lax; Max-Age=3600; Secure']),
-    )
+    expect(response.headers.getSetCookie()[0]).toEqual(expect.stringContaining('wos-session=sealed-session;'))
+    expect(response.headers.getSetCookie()[0]).toEqual(expect.stringContaining('Max-Age=3600'))
+    expect(response.headers.getSetCookie()[0]).toEqual(expect.stringContaining('Secure'))
   })
 })

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -46,22 +46,48 @@ function shouldSetSecureCookie(request: NextRequest, sameSite: string) {
   return requestUrl.protocol === 'https:' || process.env.NODE_ENV === 'production'
 }
 
-function serializeWorkOSSessionCookie(request: NextRequest, encryptedSession: string) {
+function getWorkOSSessionCookieOptions(request: NextRequest) {
   const sameSite = readCookieSameSite()
+  const options = {
+    path: '/',
+    httpOnly: true,
+    sameSite,
+    maxAge: readCookieMaxAge(),
+    secure: shouldSetSecureCookie(request, sameSite),
+    domain: process.env.WORKOS_COOKIE_DOMAIN?.trim() || undefined,
+  } as const
+
+  return options
+}
+
+function serializeWorkOSSessionCookie(request: NextRequest, encryptedSession: string) {
+  const options = getWorkOSSessionCookieOptions(request)
   const parts = [
     `${WORKOS_SESSION_COOKIE}=${encryptedSession}`,
     'Path=/',
     'HttpOnly',
-    `SameSite=${sameSite.charAt(0).toUpperCase()}${sameSite.slice(1)}`,
-    `Max-Age=${readCookieMaxAge()}`,
+    `SameSite=${options.sameSite.charAt(0).toUpperCase()}${options.sameSite.slice(1)}`,
+    `Max-Age=${options.maxAge}`,
   ]
 
-  const domain = process.env.WORKOS_COOKIE_DOMAIN?.trim()
-  if (domain) parts.push(`Domain=${domain}`)
-
-  if (shouldSetSecureCookie(request, sameSite)) parts.push('Secure')
+  if (options.domain) parts.push(`Domain=${options.domain}`)
+  if (options.secure) parts.push('Secure')
 
   return parts.join('; ')
+}
+
+function setWorkOSSessionCookie(response: Response, request: NextRequest, encryptedSession: string) {
+  if ('cookies' in response) {
+    const cookies = response.cookies as {
+      set?: (name: string, value: string, options: ReturnType<typeof getWorkOSSessionCookieOptions>) => void
+    }
+    if (typeof cookies.set === 'function') {
+      cookies.set(WORKOS_SESSION_COOKIE, encryptedSession, getWorkOSSessionCookieOptions(request))
+      return
+    }
+  }
+
+  response.headers.append('Set-Cookie', serializeWorkOSSessionCookie(request, encryptedSession))
 }
 
 async function sealAuthKitCookieSession(session: AuthKitCookieSession) {
@@ -89,10 +115,7 @@ export async function GET(request: NextRequest) {
   })(request)
 
   if (cookieSession) {
-    response.headers.append(
-      'Set-Cookie',
-      serializeWorkOSSessionCookie(request, await sealAuthKitCookieSession(cookieSession)),
-    )
+    setWorkOSSessionCookie(response, request, await sealAuthKitCookieSession(cookieSession))
   }
 
   return response


### PR DESCRIPTION
## Summary
- write the WorkOS session cookie through `NextResponse.cookies.set()` on successful AuthKit callbacks
- keep a serialized `Set-Cookie` fallback for non-Next responses
- make `/admin` wait for an incoming request before rendering the admin landing page

## Why
The production loop is `/admin -> AuthKit -> /auth/callback -> /admin -> AuthKit`. The callback returns a 307, but the next `/admin` request still has no usable WorkOS session. The session cookie should be written through NextResponse's cookie API instead of manually appending a serialized header to the redirect response.

## Verification
- `bun run test src/app/auth/callback/route.test.ts src/app/admin/page.test.tsx src/app/admin/pet-gallery/page.test.tsx src/app/admin/layout.test.tsx`
- `bun run check`
- `bun run format:check`
- `bun run build`