### PR TITLE
KTY-35 Fix production admin WorkOS session

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "date-fns": "4.3.0",
         "exifr": "7.1.3",
         "iron-session": "8.0.4",
+        "jose": "6.2.3",
         "js-cookie": "3.0.7",
         "lucide-react": "1.16.0",
         "motion": "12.38.0",
@@ -868,7 +869,7 @@
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
-    "jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "js-cookie": ["js-cookie@3.0.7", "", {}, "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw=="],
 
@@ -1181,6 +1182,8 @@
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@vitest/expect/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@workos-inc/authkit-nextjs/jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
 
     "convex/esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "date-fns": "4.3.0",
     "exifr": "7.1.3",
     "iron-session": "8.0.4",
+    "jose": "6.2.3",
     "js-cookie": "3.0.7",
     "lucide-react": "1.16.0",
     "motion": "12.38.0",

--- a/src/lib/admin-auth.test.ts
+++ b/src/lib/admin-auth.test.ts
@@ -4,6 +4,8 @@ import { ADMIN_TEST_BYPASS_COOKIE, ADMIN_TEST_BYPASS_COOKIE_VALUE } from './admi
 const withAuth = vi.fn()
 const cookieGet = vi.fn()
 const headersGet = vi.fn()
+const unsealData = vi.fn()
+const jwtVerify = vi.fn()
 const notFound = vi.fn(() => {
   throw new Error('not-found')
 })
@@ -27,6 +29,16 @@ const BASE_ENV = {
 
 vi.mock('@workos-inc/authkit-nextjs', () => ({
   withAuth,
+}))
+
+vi.mock('iron-session', () => ({
+  unsealData,
+}))
+
+vi.mock('jose', () => ({
+  createRemoteJWKSet: vi.fn(() => 'jwks'),
+  decodeJwt: vi.fn(() => ({ sid: 'session_cookie', org_id: 'org_allowed' })),
+  jwtVerify,
 }))
 
 vi.mock('next/headers', () => ({
@@ -68,6 +80,8 @@ describe('requireAdminSession', () => {
     withAuth.mockReset()
     cookieGet.mockReset()
     headersGet.mockReset()
+    unsealData.mockReset()
+    jwtVerify.mockReset()
     vi.clearAllMocks()
   })
 
@@ -122,6 +136,30 @@ describe('requireAdminSession', () => {
     const { requireAdminAuthContext } = await importAdminAuth()
 
     await expect(requireAdminAuthContext()).rejects.toThrow('Admin access denied')
+  })
+
+  it('falls back to a verified WorkOS session cookie when middleware auth headers are missing', async () => {
+    withAuth.mockResolvedValue({ user: null })
+    cookieGet.mockImplementation((name: string) =>
+      name === 'wos-session' ? { name: 'wos-session', value: 'sealed-session' } : undefined,
+    )
+    unsealData.mockResolvedValue({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      user: { id: 'user_admin', email: 'Admin@Example.Test' },
+    })
+    const { requireAdminAuthContext } = await importAdminAuth()
+
+    await expect(requireAdminAuthContext()).resolves.toEqual(
+      expect.objectContaining({
+        email: 'admin@example.test',
+        workosUserId: 'user_admin',
+        workosOrgId: 'org_allowed',
+        accessToken: 'access-token',
+      }),
+    )
+    expect(unsealData).toHaveBeenCalledWith('sealed-session', { password: 'a'.repeat(32) })
+    expect(jwtVerify).toHaveBeenCalledWith('access-token', 'jwks')
   })
 
   it('rejects a signed-in WorkOS user with the wrong email', async () => {

--- a/src/lib/admin-auth.ts
+++ b/src/lib/admin-auth.ts
@@ -5,6 +5,8 @@ import {
   isAdminTestBypassEnvEnabled,
 } from '@/lib/admin-test-bypass'
 import { withAuth } from '@workos-inc/authkit-nextjs'
+import { unsealData } from 'iron-session'
+import { createRemoteJWKSet, decodeJwt, jwtVerify } from 'jose'
 import { cookies, headers } from 'next/headers'
 import { notFound, redirect } from 'next/navigation'
 
@@ -47,9 +49,18 @@ type AdminAuthCandidate = {
   accessToken: unknown
 }
 
+type AuthKitCookieSession = {
+  accessToken?: unknown
+  refreshToken?: unknown
+  user?: unknown
+  impersonator?: unknown
+  authenticationMethod?: unknown
+}
+
 const TEST_ADMIN_EMAIL = 'admin-e2e@example.invalid'
 const TEST_ADMIN_ORG_ID = 'org_test_pet_gallery_e2e'
 const TEST_ADMIN_USER_ID = 'user_test_pet_gallery_e2e'
+const workOSJwksByClientId = new Map<string, ReturnType<typeof createRemoteJWKSet>>()
 
 function normalizeEmail(email: string | null | undefined): string | null {
   const trimmed = email?.trim().toLowerCase()
@@ -84,8 +95,7 @@ function hasUsableAccessToken(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0
 }
 
-async function readAdminAuthCandidate(): Promise<AdminAuthCandidate> {
-  const session = await withAuth()
+function toAdminAuthCandidate(session: AuthKitSession): AdminAuthCandidate {
   const user = session.user as AuthKitUser | null
   const email = normalizeEmail(user?.email)
   const workosUserId = typeof user?.id === 'string' && user.id.trim() ? user.id.trim() : null
@@ -100,6 +110,85 @@ async function readAdminAuthCandidate(): Promise<AdminAuthCandidate> {
     workosOrgId,
     accessToken,
   }
+}
+
+function readWorkOSSessionCookieName() {
+  return process.env.WORKOS_COOKIE_NAME?.trim() || 'wos-session'
+}
+
+function readWorkOSJwks(clientId: string) {
+  const existing = workOSJwksByClientId.get(clientId)
+  if (existing) return existing
+
+  const jwks = createRemoteJWKSet(new URL(`https://api.workos.com/sso/jwks/${clientId}`))
+  workOSJwksByClientId.set(clientId, jwks)
+  return jwks
+}
+
+async function readVerifiedCookieSession(env: AdminAuthEnv): Promise<AuthKitSession | null> {
+  let requestCookies: Awaited<ReturnType<typeof cookies>>
+  try {
+    requestCookies = await cookies()
+  } catch {
+    return null
+  }
+
+  const cookie = requestCookies.get(readWorkOSSessionCookieName())
+  if (!cookie?.value) return null
+
+  let sealedSession: AuthKitCookieSession
+  try {
+    sealedSession = await unsealData<AuthKitCookieSession>(cookie.value, {
+      password: env.WORKOS_COOKIE_PASSWORD,
+    })
+  } catch {
+    return null
+  }
+
+  if (!asRecord(sealedSession)) return null
+  if (!hasUsableAccessToken(sealedSession.accessToken)) return null
+
+  try {
+    await jwtVerify(sealedSession.accessToken, readWorkOSJwks(env.WORKOS_CLIENT_ID))
+  } catch {
+    return null
+  }
+
+  const claims = decodeJwt(sealedSession.accessToken)
+  return {
+    sessionId: typeof claims.sid === 'string' ? claims.sid : undefined,
+    user: (sealedSession.user ?? null) as AuthKitSession['user'],
+    organizationId: typeof claims.org_id === 'string' ? claims.org_id : undefined,
+    role: typeof claims.role === 'string' ? claims.role : undefined,
+    roles: Array.isArray(claims.roles) ? claims.roles.filter((role): role is string => typeof role === 'string') : [],
+    permissions: Array.isArray(claims.permissions)
+      ? claims.permissions.filter((permission): permission is string => typeof permission === 'string')
+      : [],
+    entitlements: Array.isArray(claims.entitlements)
+      ? claims.entitlements.filter((entitlement): entitlement is string => typeof entitlement === 'string')
+      : [],
+    featureFlags: Array.isArray(claims.feature_flags)
+      ? claims.feature_flags.filter((featureFlag): featureFlag is string => typeof featureFlag === 'string')
+      : [],
+    impersonator: sealedSession.impersonator as AuthKitSession['impersonator'],
+    accessToken: sealedSession.accessToken,
+  } as AuthKitSession
+}
+
+async function readAdminAuthCandidate(env: AdminAuthEnv): Promise<AdminAuthCandidate> {
+  let session: AuthKitSession
+  try {
+    session = await withAuth()
+  } catch (error) {
+    const cookieSession = await readVerifiedCookieSession(env)
+    if (cookieSession) return toAdminAuthCandidate(cookieSession)
+    throw error
+  }
+
+  if (session.user) return toAdminAuthCandidate(session)
+
+  const cookieSession = await readVerifiedCookieSession(env)
+  return toAdminAuthCandidate(cookieSession ?? session)
 }
 
 function toAdminAuthContext(candidate: AdminAuthCandidate, env: AdminAuthEnv): AdminAuthContext | null {
@@ -191,7 +280,8 @@ export function displayNameForAdminUser(user: AuthKitUser): string | undefined {
 }
 
 export async function requireAdminAuthContext(): Promise<AdminAuthContext> {
-  const context = toAdminAuthContext(await readAdminAuthCandidate(), requireAdminAuthEnv())
+  const env = requireAdminAuthEnv()
+  const context = toAdminAuthContext(await readAdminAuthCandidate(env), env)
   if (!context) throw new AdminUnauthorizedError()
 
   return context
@@ -203,7 +293,7 @@ export async function requireAdminSession() {
     if (testAdmin) return testAdmin
 
     const env = requireAdminAuthEnv()
-    const candidate = await readAdminAuthCandidate()
+    const candidate = await readAdminAuthCandidate(env)
     const context = toAdminAuthContext(candidate, env)
     if (context) return context
 

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -26,6 +26,16 @@ describe('auth proxy', () => {
     }
   }
 
+  function expectNoStoreHeaders(response: unknown) {
+    expect(response).toBeInstanceOf(Response)
+    const headers = (response as Response).headers
+    expect(headers.get('Cache-Control')).toBe('private, no-store, no-cache, must-revalidate, max-age=0')
+    expect(headers.get('Pragma')).toBe('no-cache')
+    expect(headers.get('Expires')).toBe('0')
+    expect(headers.get('x-middleware-cache')).toBe('no-cache')
+    expect(headers.get('Vary')).toBe('Cookie')
+  }
+
   it('lets UploadThing and the admin layout handle their own authentication boundaries', async () => {
     vi.resetModules()
     const proxy = await import('./proxy')
@@ -52,13 +62,14 @@ describe('auth proxy', () => {
     vi.stubEnv('VERCEL_ENV', 'development')
     const proxy = await import('./proxy')
 
-    proxy.default(request('/admin') as never, undefined as never)
+    const response = await proxy.default(request('/admin') as never, undefined as never)
 
     expect(protectedProxyHandler).toHaveBeenCalledWith(
       expect.objectContaining({ nextUrl: { pathname: '/admin' } }),
       undefined,
     )
     expect(bypassProxyHandler).not.toHaveBeenCalled()
+    expectNoStoreHeaders(response)
     vi.unstubAllEnvs()
   })
 
@@ -69,13 +80,17 @@ describe('auth proxy', () => {
     vi.stubEnv('VERCEL_ENV', 'development')
     const proxy = await import('./proxy')
 
-    proxy.default(request('/admin/pet-gallery', ADMIN_TEST_BYPASS_COOKIE_VALUE) as never, undefined as never)
+    const response = await proxy.default(
+      request('/admin/pet-gallery', ADMIN_TEST_BYPASS_COOKIE_VALUE) as never,
+      undefined as never,
+    )
 
     expect(bypassProxyHandler).toHaveBeenCalledWith(
       expect.objectContaining({ nextUrl: { pathname: '/admin/pet-gallery' } }),
       undefined,
     )
     expect(protectedProxyHandler).not.toHaveBeenCalled()
+    expectNoStoreHeaders(response)
     vi.unstubAllEnvs()
   })
 
@@ -92,13 +107,31 @@ describe('auth proxy', () => {
     if (vercelEnv) vi.stubEnv('VERCEL_ENV', vercelEnv)
     const proxy = await import('./proxy')
 
-    proxy.default(request('/admin/pet-gallery', ADMIN_TEST_BYPASS_COOKIE_VALUE) as never, undefined as never)
+    const response = await proxy.default(
+      request('/admin/pet-gallery', ADMIN_TEST_BYPASS_COOKIE_VALUE) as never,
+      undefined as never,
+    )
 
     expect(protectedProxyHandler).toHaveBeenCalledWith(
       expect.objectContaining({ nextUrl: { pathname: '/admin/pet-gallery' } }),
       undefined,
     )
     expect(bypassProxyHandler).not.toHaveBeenCalled()
+    expectNoStoreHeaders(response)
     vi.unstubAllEnvs()
+  })
+
+  it('preserves existing Vary values when disabling cache for auth responses', async () => {
+    protectedProxyHandler.mockReturnValueOnce(new Response('protected', { headers: { Vary: 'Accept-Encoding' } }))
+    vi.resetModules()
+    const proxy = await import('./proxy')
+
+    const response = await proxy.default(request('/auth/callback') as never, undefined as never)
+
+    expect(response).toBeInstanceOf(Response)
+    expect((response as Response).headers.get('Vary')).toBe('Accept-Encoding, Cookie')
+    expect((response as Response).headers.get('Cache-Control')).toBe(
+      'private, no-store, no-cache, must-revalidate, max-age=0',
+    )
   })
 })

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -11,6 +11,7 @@ const ADMIN_PATH = '/admin/:path*'
 const ADMIN_SIGN_IN_PATH = '/auth/sign-in'
 const ADMIN_CALLBACK_PATH = '/auth/callback'
 const UNAUTHENTICATED_PATHS = [UPLOADTHING_PATH, ADMIN_PATH, ADMIN_SIGN_IN_PATH, ADMIN_CALLBACK_PATH]
+const NO_STORE_CACHE_CONTROL = 'private, no-store, no-cache, must-revalidate, max-age=0'
 
 const protectedProxy = authkitProxy({
   middlewareAuth: {
@@ -38,8 +39,42 @@ function isTestAdminBypassRequest(request: NextRequest) {
   )
 }
 
+function appendVaryCookie(response: Response) {
+  const current = response.headers.get('Vary')
+  const values = new Set(
+    (current ?? '')
+      .split(',')
+      .map(value => value.trim())
+      .filter(Boolean),
+  )
+  values.add('Cookie')
+  response.headers.set('Vary', [...values].join(', '))
+}
+
+function applyNoStoreHeaders<T>(response: T): T {
+  if (!(response instanceof Response)) return response
+
+  response.headers.set('Cache-Control', NO_STORE_CACHE_CONTROL)
+  response.headers.set('Pragma', 'no-cache')
+  response.headers.set('Expires', '0')
+  response.headers.set('x-middleware-cache', 'no-cache')
+  appendVaryCookie(response)
+  return response
+}
+
+function isPromiseLike<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {
+  return !!value && typeof (value as PromiseLike<T>).then === 'function'
+}
+
 export default function proxy(request: NextRequest, event: NextFetchEvent) {
-  return isTestAdminBypassRequest(request) ? testAdminBypassProxy(request, event) : protectedProxy(request, event)
+  const response = isTestAdminBypassRequest(request)
+    ? testAdminBypassProxy(request, event)
+    : protectedProxy(request, event)
+  if (isPromiseLike(response)) {
+    return response.then(applyNoStoreHeaders)
+  }
+
+  return applyNoStoreHeaders(response)
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- read and verify the encrypted WorkOS session cookie when AuthKit middleware headers are missing
- add no-store/cache-prevention headers to admin, auth, and UploadThing proxy responses
- add regression coverage for the cookie fallback and no-store proxy headers

Fixes KTY-35

## Verification
- bun run test
- bun run check
- bun run format:check
- bun run build