### PR TITLE
KTY-35 Refresh admin WorkOS org session

### DIFF
--- a/src/app/auth/complete/route.test.ts
+++ b/src/app/auth/complete/route.test.ts
@@ -1,0 +1,94 @@
+import type * as NextServer from 'next/server'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const refreshSession = vi.fn()
+const connection = vi.fn()
+
+vi.mock('@workos-inc/authkit-nextjs', () => ({
+  refreshSession,
+}))
+
+vi.mock('next/server', async importActual => ({
+  ...(await importActual<typeof NextServer>()),
+  connection,
+}))
+
+const BASE_ENV = {
+  NODE_ENV: 'test',
+  NEXT_PUBLIC_POSTHOG_KEY: 'test-posthog-key',
+  NEXT_PUBLIC_POSTHOG_HOST: 'https://example.test',
+  NEXT_PUBLIC_CONVEX_URL: 'https://example.convex.cloud',
+  WORKOS_API_KEY: 'sk_test_valid_test_value',
+  WORKOS_CLIENT_ID: 'client_test_valid_value',
+  WORKOS_COOKIE_PASSWORD: 'a'.repeat(32),
+  NEXT_PUBLIC_WORKOS_REDIRECT_URI: 'http://localhost:3000/auth/callback',
+  PET_GALLERY_WORKOS_ORG_ID: 'org_allowed',
+  PET_GALLERY_ADMIN_EMAIL: 'admin@example.test',
+}
+
+async function importRoute() {
+  vi.resetModules()
+  for (const [key, value] of Object.entries(BASE_ENV)) {
+    vi.stubEnv(key, value)
+  }
+
+  return import('./route')
+}
+
+function request(url: string) {
+  return new Request(url) as never
+}
+
+describe('AuthKit completion route', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.clearAllMocks()
+  })
+
+  it('refreshes the WorkOS session into the configured admin organization before returning to admin', async () => {
+    refreshSession.mockResolvedValue({ user: { id: 'user_admin' }, organizationId: 'org_allowed' })
+    const route = await importRoute()
+
+    const response = await route.GET(request('http://localhost:3000/auth/complete?returnTo=/admin/pet-gallery'))
+
+    expect(connection).toHaveBeenCalledWith()
+    expect(refreshSession).toHaveBeenCalledWith({ organizationId: 'org_allowed' })
+    expect(response.headers.get('location')).toBe('http://localhost:3000/admin/pet-gallery')
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store, no-cache, must-revalidate, max-age=0')
+    expect(response.headers.get('Pragma')).toBe('no-cache')
+    expect(response.headers.get('Expires')).toBe('0')
+    expect(response.headers.get('Vary')).toBe('Cookie')
+  })
+
+  it('falls back to org-scoped sign-in when the organization refresh fails', async () => {
+    refreshSession.mockRejectedValue(new Error('refresh failed'))
+    const route = await importRoute()
+
+    const response = await route.GET(request('http://localhost:3000/auth/complete?returnTo=/admin/pet-gallery'))
+
+    expect(response.headers.get('location')).toBe('http://localhost:3000/auth/sign-in?returnTo=%2Fadmin%2Fpet-gallery')
+  })
+
+  it.each(['https://evil.example.test/admin', '//evil.example.test/admin', '/projects', '/administrator'])(
+    'falls back to /admin for unsafe return path %s',
+    async returnTo => {
+      refreshSession.mockResolvedValue({ user: { id: 'user_admin' }, organizationId: 'org_allowed' })
+      const route = await importRoute()
+
+      const response = await route.GET(
+        request(`http://localhost:3000/auth/complete?returnTo=${encodeURIComponent(returnTo)}`),
+      )
+
+      expect(response.headers.get('location')).toBe('http://localhost:3000/admin')
+    },
+  )
+
+  it('falls back to sign-in if refresh returns a session outside the configured organization', async () => {
+    refreshSession.mockResolvedValue({ user: { id: 'user_admin' }, organizationId: 'org_other' })
+    const route = await importRoute()
+
+    const response = await route.GET(request('http://localhost:3000/auth/complete?returnTo=/admin'))
+
+    expect(response.headers.get('location')).toBe('http://localhost:3000/auth/sign-in?returnTo=%2Fadmin')
+  })
+})

--- a/src/app/auth/complete/route.ts
+++ b/src/app/auth/complete/route.ts
@@ -1,0 +1,53 @@
+import { requireAdminAuthEnv } from '@/env'
+import { refreshSession } from '@workos-inc/authkit-nextjs'
+import { connection, NextResponse, type NextRequest } from 'next/server'
+
+const NO_STORE_CACHE_CONTROL = 'private, no-store, no-cache, must-revalidate, max-age=0'
+
+function readSafeReturnTo(request: NextRequest) {
+  const requestUrl = request.nextUrl ?? new URL(request.url)
+  const returnTo = requestUrl.searchParams.get('returnTo')
+  if (!returnTo) return '/admin'
+
+  try {
+    const parsed = new URL(returnTo, requestUrl.origin)
+    if (parsed.origin !== requestUrl.origin) return '/admin'
+    if (parsed.pathname !== '/admin' && !parsed.pathname.startsWith('/admin/')) return '/admin'
+    return `${parsed.pathname}${parsed.search}`
+  } catch {
+    return '/admin'
+  }
+}
+
+function applyNoStoreHeaders(response: NextResponse) {
+  response.headers.set('Cache-Control', NO_STORE_CACHE_CONTROL)
+  response.headers.set('Pragma', 'no-cache')
+  response.headers.set('Expires', '0')
+  response.headers.set('Vary', 'Cookie')
+  return response
+}
+
+function redirectToSignIn(request: NextRequest, returnTo: string) {
+  const url = new URL('/auth/sign-in', request.url)
+  url.searchParams.set('returnTo', returnTo)
+  return applyNoStoreHeaders(NextResponse.redirect(url))
+}
+
+export async function GET(request: NextRequest) {
+  await connection()
+
+  const returnTo = readSafeReturnTo(request)
+  const { PET_GALLERY_WORKOS_ORG_ID } = requireAdminAuthEnv()
+
+  try {
+    const session = await refreshSession({ organizationId: PET_GALLERY_WORKOS_ORG_ID })
+    if (session.organizationId !== PET_GALLERY_WORKOS_ORG_ID) {
+      throw new Error('WorkOS session did not refresh into the configured admin organization')
+    }
+  } catch (error) {
+    console.error('[admin-auth] Failed to refresh WorkOS organization session', error)
+    return redirectToSignIn(request, returnTo)
+  }
+
+  return applyNoStoreHeaders(NextResponse.redirect(new URL(returnTo, request.url)))
+}

--- a/src/lib/admin-auth.test.ts
+++ b/src/lib/admin-auth.test.ts
@@ -112,22 +112,22 @@ describe('requireAdminSession', () => {
     expect(notFound).not.toHaveBeenCalled()
   })
 
-  it('redirects a configured admin in the wrong organization through org-scoped sign-in', async () => {
+  it('redirects a configured admin in the wrong organization through org session completion', async () => {
     headersGet.mockReturnValue('http://localhost:3000/admin/pet-gallery')
     withAuth.mockResolvedValue(validAdminSession({ organizationId: 'org_other' }))
     const { requireAdminSession } = await importAdminAuth()
 
-    await expect(requireAdminSession()).rejects.toThrow('redirect:/auth/sign-in?returnTo=%2Fadmin%2Fpet-gallery')
-    expect(redirect).toHaveBeenCalledWith('/auth/sign-in?returnTo=%2Fadmin%2Fpet-gallery')
+    await expect(requireAdminSession()).rejects.toThrow('redirect:/auth/complete?returnTo=%2Fadmin%2Fpet-gallery')
+    expect(redirect).toHaveBeenCalledWith('/auth/complete?returnTo=%2Fadmin%2Fpet-gallery')
     expect(notFound).not.toHaveBeenCalled()
   })
 
-  it('redirects a configured admin without an organization through org-scoped sign-in', async () => {
+  it('redirects a configured admin without an organization through org session completion', async () => {
     withAuth.mockResolvedValue(validAdminSession({ organizationId: undefined }))
     const { requireAdminSession } = await importAdminAuth()
 
-    await expect(requireAdminSession()).rejects.toThrow('redirect:/auth/sign-in?returnTo=%2Fadmin')
-    expect(redirect).toHaveBeenCalledWith('/auth/sign-in?returnTo=%2Fadmin')
+    await expect(requireAdminSession()).rejects.toThrow('redirect:/auth/complete?returnTo=%2Fadmin')
+    expect(redirect).toHaveBeenCalledWith('/auth/complete?returnTo=%2Fadmin')
     expect(notFound).not.toHaveBeenCalled()
   })
 

--- a/src/lib/admin-auth.ts
+++ b/src/lib/admin-auth.ts
@@ -215,7 +215,7 @@ function toAdminAuthContext(candidate: AdminAuthCandidate, env: AdminAuthEnv): A
   }
 }
 
-function shouldReauthenticateConfiguredAdminForOrganization(candidate: AdminAuthCandidate, env: AdminAuthEnv) {
+function shouldRefreshConfiguredAdminOrganizationSession(candidate: AdminAuthCandidate, env: AdminAuthEnv) {
   return (
     !!candidate.user &&
     !!candidate.workosUserId &&
@@ -240,6 +240,11 @@ async function getAdminReturnPathname() {
 async function redirectToConfiguredAdminSignIn(): Promise<never> {
   const returnTo = encodeURIComponent(await getAdminReturnPathname())
   redirect(`/auth/sign-in?returnTo=${returnTo}` as Parameters<typeof redirect>[0])
+}
+
+async function redirectToConfiguredAdminOrganizationRefresh(): Promise<never> {
+  const returnTo = encodeURIComponent(await getAdminReturnPathname())
+  redirect(`/auth/complete?returnTo=${returnTo}` as Parameters<typeof redirect>[0])
 }
 
 async function readTestAdminBypass(): Promise<AdminSessionContext | null> {
@@ -301,8 +306,8 @@ export async function requireAdminSession() {
       await redirectToConfiguredAdminSignIn()
     }
 
-    if (shouldReauthenticateConfiguredAdminForOrganization(candidate, env)) {
-      await redirectToConfiguredAdminSignIn()
+    if (shouldRefreshConfiguredAdminOrganizationSession(candidate, env)) {
+      await redirectToConfiguredAdminOrganizationRefresh()
     }
 
     throw new AdminUnauthorizedError()


### PR DESCRIPTION
## Summary
- add an AuthKit completion route that refreshes the logged-in session into the configured admin WorkOS organization
- redirect configured admin sessions with a missing/wrong org claim through that completion route instead of starting another sign-in loop
- cover the org-refresh flow, unsafe return paths, and fallback sign-in behavior with tests

Closes KTY-35

## Verification
- bun run test src/lib/admin-auth.test.ts src/app/auth/complete/route.test.ts src/app/auth/sign-in/route.test.ts src/app/auth/callback/route.test.ts src/proxy.test.ts
- bun run check
- bun run format:check
- bun run build
- bun run test
- production-style local curl checks for /admin and /auth/complete on port 3012

## Production note
I cannot complete the Google login in the user browser from this shell. The production logs showed /auth/callback -> /admin 200 -> /auth/sign-in, which matches a signed-in session that failed the admin org claim check during render. This patch refreshes that session into the configured org in a route handler where AuthKit is allowed to write cookies.