### PR TITLE
KTY-35 Fix Convex WorkOS auth provider deployment

### DIFF
--- a/convex/auth.test.ts
+++ b/convex/auth.test.ts
@@ -49,6 +49,33 @@ describe('Convex WorkOS auth config', () => {
     ])
   })
 
+  it('reads WorkOS client ID from Convex auth config process environment shape', async () => {
+    const originalEnv = process.env
+    process.env = Object.assign(Object.create({ WORKOS_CLIENT_ID: 'client_test_inherited' }), {}) as NodeJS.ProcessEnv
+
+    try {
+      const { getWorkOSAuthConfigProviders } = await import('./auth')
+
+      expect(getWorkOSAuthConfigProviders()).toEqual([
+        {
+          type: 'customJwt',
+          issuer: 'https://api.workos.com/',
+          algorithm: 'RS256',
+          jwks: 'https://api.workos.com/sso/jwks/client_test_inherited',
+          applicationID: 'client_test_inherited',
+        },
+        {
+          type: 'customJwt',
+          issuer: 'https://api.workos.com/user_management/client_test_inherited',
+          algorithm: 'RS256',
+          jwks: 'https://api.workos.com/sso/jwks/client_test_inherited',
+        },
+      ])
+    } finally {
+      process.env = originalEnv
+    }
+  })
+
   it('builds Convex auth providers when the optional WorkOS action secret is missing', async () => {
     vi.stubEnv('WORKOS_CLIENT_ID', 'client_test_valid')
     vi.stubEnv('WORKOS_API_KEY', 'sk_test_valid')

--- a/convex/authConfigProviders.ts
+++ b/convex/authConfigProviders.ts
@@ -1,7 +1,6 @@
 import type { AuthConfig } from 'convex/server'
 
 function readOptionalAuthConfigEnv(key: string) {
-  if (!Object.prototype.hasOwnProperty.call(process.env, key)) return
   const value = process.env[key]?.trim()
   return value || undefined
 }


### PR DESCRIPTION
## Summary
- Fix Convex auth config env lookup so WorkOS providers are included during Convex deploy
- Add regression coverage for Convex auth.config-style process.env shape

## Verification
- bun run test convex/auth.test.ts
- bunx tsc --noEmit --pretty false
- bun run check
- bunx convex deploy --dry-run --verbose --typecheck disable --yes showed WorkOS customJwt providers in appAuth
- Deployed Convex and production Vercel; verified https://kil.dev/admin/pet-gallery loads in the in-app browser

Closes KTY-35