### PR TITLE
Bundle small Linear fixes

### DIFF
--- a/convex/http.test.ts
+++ b/convex/http.test.ts
@@ -40,9 +40,7 @@ describe('Convex WorkOS HTTP routes', () => {
 
     const handler = httpAction.mock.calls[0]?.[0]
     const response = await handler?.()
-    await expect(response?.text()).resolves.toBe(
-      'WorkOS AuthKit environment is not configured: WORKOS_CLIENT_ID, WORKOS_WEBHOOK_SECRET',
-    )
+    await expect(response?.text()).resolves.toBe('WorkOS AuthKit environment is not configured')
     expect(response?.status).toBe(503)
   })
 

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -8,12 +8,13 @@ const missingAuthKitEnv = getMissingWorkOSAuthKitEnv()
 if (missingAuthKitEnv.length === 0) {
   getAuthKit().registerRoutes(http)
 } else {
-  const missingEnvHandler = httpAction(
-    async () =>
-      new Response(`WorkOS AuthKit environment is not configured: ${missingAuthKitEnv.join(', ')}`, {
-        status: 503,
-      }),
-  )
+  const missingEnvHandler = httpAction(async () => {
+    console.error(`WorkOS AuthKit environment is not configured: ${missingAuthKitEnv.join(', ')}`)
+
+    return new Response('WorkOS AuthKit environment is not configured', {
+      status: 503,
+    })
+  })
 
   http.route({
     path: '/workos/webhook',

--- a/src/app/about/head.test.tsx
+++ b/src/app/about/head.test.tsx
@@ -1,0 +1,24 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/images/pets', () => ({
+  Azazel: { src: '/pets/azazel.webp' },
+  Gozer: { src: '/pets/gozer.webp' },
+  Gwen: { src: '/pets/gwen.webp' },
+  Lilith: { src: '/pets/lilith.webp' },
+  Lux: { src: '/pets/lux.webp' },
+  Tali: { src: '/pets/tali.webp' },
+}))
+
+import { PETS } from '@/lib/pets'
+import Head from './head'
+
+describe('/about head', () => {
+  it('preloads every about page pet image', () => {
+    const html = renderToStaticMarkup(<Head />)
+
+    for (const pet of PETS) {
+      expect(html).toContain(`href="${pet.image.src}"`)
+    }
+  })
+})

--- a/src/app/about/head.tsx
+++ b/src/app/about/head.tsx
@@ -1,13 +1,11 @@
-import * as Pets from '@/images/pets'
+import { PETS } from '@/lib/pets'
 
 export default function Head() {
   return (
     <>
-      <link rel="preload" as="image" href={Pets.Azazel.src} />
-      <link rel="preload" as="image" href={Pets.Gozer.src} />
-      <link rel="preload" as="image" href={Pets.Lilith.src} />
-      <link rel="preload" as="image" href={Pets.Lux.src} />
-      <link rel="preload" as="image" href={Pets.Tali.src} />
+      {PETS.map(pet => (
+        <link key={pet.id} rel="preload" as="image" href={pet.image.src} />
+      ))}
     </>
   )
 }

--- a/src/app/api/scores/check/[score]/route.test.ts
+++ b/src/app/api/scores/check/[score]/route.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { checkScoreQualification } from '@/lib/leaderboard'
+import { GET } from './route'
+
+vi.mock('@/lib/leaderboard', () => ({
+  checkScoreQualification: vi.fn(),
+}))
+
+const mockedCheckScoreQualification = vi.mocked(checkScoreQualification)
+
+function checkScore(score?: string) {
+  return GET(new Request('http://localhost/api/scores/check'), {
+    params: Promise.resolve({ score }),
+  })
+}
+
+describe('GET /api/scores/check/[score]', () => {
+  beforeEach(() => {
+    mockedCheckScoreQualification.mockReset()
+    mockedCheckScoreQualification.mockResolvedValue({ qualifies: true, threshold: 100 })
+  })
+
+  it.each(['123abc', '1.5', '-1', '', 'abc'])('rejects malformed score param %s', async score => {
+    const response = await checkScore(score)
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({ success: false })
+    expect(mockedCheckScoreQualification).not.toHaveBeenCalled()
+  })
+
+  it('accepts strict non-negative integer score params', async () => {
+    const response = await checkScore('123')
+
+    expect(response.status).toBe(200)
+    expect(mockedCheckScoreQualification).toHaveBeenCalledWith(123)
+  })
+})

--- a/src/app/api/scores/check/[score]/route.ts
+++ b/src/app/api/scores/check/[score]/route.ts
@@ -7,15 +7,11 @@ export async function GET(_request: Request, context: { params: Promise<{ score?
   try {
     const { score: scoreParam } = await context.params
 
-    if (!scoreParam) {
-      return NextResponse.json({ success: false, message: 'Score parameter is required' }, { status: 400 })
-    }
-
-    const score = Number.parseInt(scoreParam, 10)
-
-    if (Number.isNaN(score) || score < 0) {
+    if (!scoreParam || !/^\d+$/.test(scoreParam)) {
       return NextResponse.json({ success: false, message: 'Invalid score value' }, { status: 400 })
     }
+
+    const score = Number(scoreParam)
 
     const { qualifies, threshold } = await checkScoreQualification(score)
 

--- a/src/components/providers/posthog-provider.test.ts
+++ b/src/components/providers/posthog-provider.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildPostHogInitOptions } from './posthog-provider'
+
+describe('buildPostHogInitOptions', () => {
+  it('uses the configured PostHog host for direct ingestion', () => {
+    expect(buildPostHogInitOptions('https://eu.i.posthog.com')).toMatchObject({
+      api_host: 'https://eu.i.posthog.com',
+      ui_host: 'https://eu.posthog.com',
+    })
+  })
+
+  it('keeps the local PostHog proxy aligned with the US UI host', () => {
+    expect(buildPostHogInitOptions('/vibecheck')).toMatchObject({
+      api_host: '/vibecheck',
+      ui_host: 'https://us.posthog.com',
+    })
+  })
+})

--- a/src/components/providers/posthog-provider.tsx
+++ b/src/components/providers/posthog-provider.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { shouldInitializePostHog } from '@/lib/posthog-config'
 import { isDev } from '@/utils/utils'
 import { useEffect, useState } from 'react'
 
@@ -28,11 +29,16 @@ function getPostHogUiHost(apiHost: string) {
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY
   const posthogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST
-  const canCapture = !isDev() && !!posthogKey && !!posthogHost
+  const canCapture = shouldInitializePostHog({
+    isDevRuntime: isDev(),
+    posthogDisabled: process.env.NEXT_PUBLIC_POSTHOG_DISABLED,
+    posthogHost,
+    posthogKey,
+  })
   const [isInitialized, setIsInitialized] = useState(false)
 
   useEffect(() => {
-    if (!canCapture || isInitialized) return
+    if (!canCapture || isInitialized || !posthogKey || !posthogHost) return
 
     let idleId: number | undefined
     let timeoutId: ReturnType<typeof setTimeout> | undefined

--- a/src/components/providers/posthog-provider.tsx
+++ b/src/components/providers/posthog-provider.tsx
@@ -3,9 +3,32 @@
 import { isDev } from '@/utils/utils'
 import { useEffect, useState } from 'react'
 
+const US_POSTHOG_UI_HOST = 'https://us.posthog.com'
+const EU_POSTHOG_UI_HOST = 'https://eu.posthog.com'
+
+export function buildPostHogInitOptions(posthogHost: string) {
+  const apiHost = posthogHost.trim()
+
+  return {
+    api_host: apiHost,
+    ui_host: getPostHogUiHost(apiHost),
+    defaults: '2025-05-24' as const,
+    capture_exceptions: true,
+    debug: false,
+  }
+}
+
+function getPostHogUiHost(apiHost: string) {
+  if (apiHost === '/vibecheck' || apiHost === 'https://us.i.posthog.com') return US_POSTHOG_UI_HOST
+  if (apiHost === 'https://eu.i.posthog.com') return EU_POSTHOG_UI_HOST
+
+  return apiHost
+}
+
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY
-  const canCapture = !isDev() && !!posthogKey
+  const posthogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST
+  const canCapture = !isDev() && !!posthogKey && !!posthogHost
   const [isInitialized, setIsInitialized] = useState(false)
 
   useEffect(() => {
@@ -19,11 +42,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       import('posthog-js')
         .then(({ default: posthog }) => {
           posthog.init(posthogKey, {
-            api_host: '/vibecheck',
-            ui_host: 'https://us.posthog.com',
-            defaults: '2025-05-24',
-            capture_exceptions: true,
-            debug: false,
+            ...buildPostHogInitOptions(posthogHost),
             // Additional performance optimizations
             loaded: () => {
               setIsInitialized(true)
@@ -51,7 +70,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
         clearTimeout(timeoutId)
       }
     }
-  }, [canCapture, posthogKey, isInitialized])
+  }, [canCapture, posthogKey, posthogHost, isInitialized])
 
   return <>{children}</>
 }

--- a/src/hooks/posthog.ts
+++ b/src/hooks/posthog.ts
@@ -1,8 +1,13 @@
+import { shouldCapturePostHogEvents } from '@/lib/posthog-config'
 import { isDev } from '@/utils/utils'
 import type { Route } from 'next'
 
 const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY
-const canCapture = !isDev() && !!posthogKey
+const canCapture = shouldCapturePostHogEvents({
+  isDevRuntime: isDev(),
+  posthogDisabled: process.env.NEXT_PUBLIC_POSTHOG_DISABLED,
+  posthogKey,
+})
 
 // Centralized event property names for consistent usage across all PostHog events
 enum PostHogEventProperties {

--- a/src/lib/posthog-config.test.ts
+++ b/src/lib/posthog-config.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldInitializePostHog } from './posthog-config'
+
+describe('shouldInitializePostHog', () => {
+  it('does not initialize when PostHog is explicitly disabled', () => {
+    expect(
+      shouldInitializePostHog({
+        isDevRuntime: false,
+        posthogDisabled: '1',
+        posthogHost: 'test-host',
+        posthogKey: 'test-key',
+      }),
+    ).toBe(false)
+  })
+
+  it('initializes in production when PostHog is configured and enabled', () => {
+    expect(
+      shouldInitializePostHog({
+        isDevRuntime: false,
+        posthogHost: '/vibecheck',
+        posthogKey: 'test-key',
+      }),
+    ).toBe(true)
+  })
+})

--- a/src/lib/posthog-config.ts
+++ b/src/lib/posthog-config.ts
@@ -1,0 +1,27 @@
+export type PostHogRuntimeConfig = {
+  isDevRuntime: boolean
+  posthogDisabled?: string
+  posthogHost?: string
+  posthogKey?: string
+}
+
+function isPostHogDisabled(value: string | undefined) {
+  return value === '1' || value?.toLowerCase() === 'true'
+}
+
+export function shouldInitializePostHog({
+  isDevRuntime,
+  posthogDisabled,
+  posthogHost,
+  posthogKey,
+}: PostHogRuntimeConfig) {
+  return !isDevRuntime && !isPostHogDisabled(posthogDisabled) && !!posthogKey && !!posthogHost
+}
+
+export function shouldCapturePostHogEvents({
+  isDevRuntime,
+  posthogDisabled,
+  posthogKey,
+}: Omit<PostHogRuntimeConfig, 'posthogHost'>) {
+  return !isDevRuntime && !isPostHogDisabled(posthogDisabled) && !!posthogKey
+}


### PR DESCRIPTION
## Summary
- KTY-41: Generate `/about` pet image preloads from `PETS`, covering Gwen and future additions.
- KTY-44: Reject malformed score check route params before qualification lookup.
- KTY-42: Respect `NEXT_PUBLIC_POSTHOG_HOST` when initializing PostHog.
- KTY-46: Return a generic public WorkOS AuthKit 503 body while logging detailed missing env names server-side.

## Validation
- `bun run test`
- `bun run check`
- `bun run format:check`